### PR TITLE
FIx attribute name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "random_string" "this" {
   length  = 32 - length(var.bucket_name)
   upper   = false
   lower   = true
-  number  = true
+  numeric = true
   special = false
 }
 


### PR DESCRIPTION
**NOTE**: This is deprecated, use `numeric` instead.